### PR TITLE
337 不能使用 prein2Tree 方法建立二叉树

### DIFF
--- a/Algorithms/0337.house-robber-iii/house-robber-iii_test.go
+++ b/Algorithms/0337.house-robber-iii/house-robber-iii_test.go
@@ -4,32 +4,28 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aQuaYi/LeetCode-in-Go/kit"
-
 	"github.com/stretchr/testify/assert"
 )
 
 // tcs is testcase slice
 var tcs = []struct {
-	pre, in []int
-	ans     int
+	nums []int
+	ans  int
 }{
 
+	// 用 0 表示 nil
 	{
-		[]int{5, 2, 4, 1, 3, 1000},
-		[]int{2, 4, 5, 1, 3, 1000},
-		1009,
+		[]int{4, 1, 0, 2, 0, 3},
+		7,
 	},
 
 	{
-		[]int{5, 2, 4, 1, 3},
-		[]int{2, 4, 5, 1, 3},
-		12,
+		[]int{3, 2, 3, 0, 3, 0, 1},
+		7,
 	},
 
 	{
-		[]int{3, 4, 1, 3, 5, 1},
-		[]int{1, 4, 3, 3, 5, 1},
+		[]int{3, 4, 5, 1, 3, 0, 1},
 		9,
 	},
 
@@ -41,7 +37,8 @@ func Test_rob(t *testing.T) {
 
 	for _, tc := range tcs {
 		fmt.Printf("~~%v~~\n", tc)
-		root := kit.PreIn2Tree(tc.pre, tc.in)
+		root := &TreeNode{}
+		initTree(tc.nums, []*TreeNode{}, root)
 		ast.Equal(tc.ans, rob(root), "输入:%v", tc)
 	}
 }
@@ -49,8 +46,48 @@ func Test_rob(t *testing.T) {
 func Benchmark_rob(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, tc := range tcs {
-			root := kit.PreIn2Tree(tc.pre, tc.in)
+			root := &TreeNode{}
+			initTree(tc.nums, []*TreeNode{}, root)
 			rob(root)
 		}
 	}
+}
+
+// 创建二叉树
+func initTree(nums []int, parents []*TreeNode, root *TreeNode) {
+	if len(nums) == 0 {
+		return
+	}
+
+	if len(parents) == 0 {
+		if nums[0] != 0 {
+			root.Val = nums[0]
+			parents = append(parents, root)
+			initTree(nums[1:], parents, root)
+		}
+
+		return
+	}
+
+	newParents := make([]*TreeNode, 0, len(parents)*2)
+	for _, parent := range parents {
+
+		if nums[0] != 0 {
+			parent.Left = &TreeNode{Val: nums[0]}
+			newParents = append(newParents, parent.Left)
+		}
+
+		if len(nums) == 1 {
+			return
+		}
+
+		if nums[1] != 0 {
+			parent.Right = &TreeNode{Val: nums[1]}
+			newParents = append(newParents, parent.Right)
+		}
+
+		nums = nums[2:]
+	}
+
+	initTree(nums, newParents, root)
 }

--- a/Algorithms/0342.power-of-four/power-of-four.go
+++ b/Algorithms/0342.power-of-four/power-of-four.go
@@ -1,13 +1,19 @@
 package problem0342
 
-func isPowerOfFour(n int) bool {
-	if n < 1 {
+func isPowerOfFour(num int) bool {
+	if num <= 0 {
 		return false
 	}
 
-	for n%4 == 0 {
-		n /= 4
+	// 如果 num 不是2的N次方, 那么也不是4的N次方
+	if num&(num-1) != 0 {
+		return false
 	}
-	
-	return n == 1
+
+	// 过滤
+	if num&0x55555555 == 0 {
+		return false
+	}
+
+	return true
 }

--- a/Algorithms/0342.power-of-four/power-of-four_test.go
+++ b/Algorithms/0342.power-of-four/power-of-four_test.go
@@ -13,6 +13,7 @@ var tcs = []struct {
 	ans bool
 }{
 
+	{2, false},
 	{16, true},
 	{5, false},
 	{-5, false},


### PR DESCRIPTION
当有两个相同值的节点时 indexOf 方法可能会返回不正确的 idx, 从而不能建立出正确的二叉树